### PR TITLE
fix(taskservice): delete last tasks

### DIFF
--- a/src/main/java/ch/heigvd/ios/text/TextFileWriter.java
+++ b/src/main/java/ch/heigvd/ios/text/TextFileWriter.java
@@ -13,7 +13,7 @@ public class TextFileWriter {
         try (FileWriter writer = new FileWriter(filename, StandardCharsets.UTF_8))
         {
             BufferedWriter bw = new BufferedWriter(writer);
-            bw.write("\n" + taches);
+            bw.write(taches);
 
             bw.flush();
             bw.close();

--- a/src/main/java/ch/heigvd/services/TaskService.java
+++ b/src/main/java/ch/heigvd/services/TaskService.java
@@ -146,10 +146,6 @@ public class TaskService {
 	}
 
 	private void saveTasks(List<Task> tasks) {
-		if (tasks.isEmpty()) {
-			// TODO: clear file?
-			return;
-		}
 		TextFileWriter fw = new TextFileWriter();
 		fw.write(tasksFile.getPath(), formattedTasksString(tasks));
 	}


### PR DESCRIPTION
As mentioned in #40, we were not writing to the file when performing an action that would delete the last task(s) from storage.

## Solution
We were checking if array was empty in TaskService.saveTasks() and doing nothing in that case (was a TODO item... ) :(

## Result
**setup**:
```bash
$ cat ./.todo.tlst
2 | Review code changes | 2025-10-09 | 2025-10-12 | HIGH   | DONE
3 | Finish POC          | 2025-10-09 | 2025-10-14 | MEDIUM | DONE
```
**previous issue**:
```bash
$ java -jar target/java-ios-1.0-SNAPSHOT.jar clear
Cleared 2 completed task(s):
2 | Review code changes | 2025-10-09 | 2025-10-12 | HIGH   | DONE
3 | Finish POC          | 2025-10-09 | 2025-10-14 | MEDIUM | DONE
```

**result**:
```bash
$ java -jar target/java-ios-1.0-SNAPSHOT.jar list
No tasks found.
```